### PR TITLE
Fix for a problem with magento 1.7.0.2 (can't activate the theme)

### DIFF
--- a/app/code/community/JR/AdminTheme/etc/config.xml
+++ b/app/code/community/JR/AdminTheme/etc/config.xml
@@ -10,6 +10,10 @@
             <design>
                 <theme>
                     <default>go</default>
+                    <skin>go</skin>
+                    <layout>go</layout>
+                    <template>go</template>
+                    <locale>go</locale>
                 </theme>
             </design>
         </admin>


### PR DESCRIPTION
I had problems with magento 1.7.0.2 (it is a clean installation with a custom frontend theme). The admin theme didn't show up,  tried everything but it didn't work.
I did some debug and the only solution I found was modifying the config.xml. Please have a look at it.
